### PR TITLE
Updating Indicator 3-1-1

### DIFF
--- a/data/indicator_3-1-1.csv
+++ b/data/indicator_3-1-1.csv
@@ -1,15 +1,15 @@
 Year,Mortality Association Type,Units,Value
-2011,Pregnancy Asociated,"Ratio per 100,000 live births",60.4
-2012,Pregnancy Asociated,"Ratio per 100,000 live births",50.6
-2013,Pregnancy Asociated,"Ratio per 100,000 live births",51.9
-2014,Pregnancy Asociated,"Ratio per 100,000 live births",70.8
-2015,Pregnancy Asociated,"Ratio per 100,000 live births",68.9
-2016,Pregnancy Asociated,"Ratio per 100,000 live births",82.0
-2017,Pregnancy Asociated,"Ratio per 100,000 live births",69.1
-2018,Pregnancy Asociated,"Ratio per 100,000 live births",74.5
-2019,Pregnancy Asociated,"Ratio per 100,000 live births",76.9
-2020,Pregnancy Asociated,"Ratio per 100,000 live births",102.7
-2021,Pregnancy Asociated,"Ratio per 100,000 live births",92.4
+2011,Pregnancy Associated,"Ratio per 100,000 live births",60.4
+2012,Pregnancy Associated,"Ratio per 100,000 live births",50.6
+2013,Pregnancy Associated,"Ratio per 100,000 live births",51.9
+2014,Pregnancy Associated,"Ratio per 100,000 live births",70.8
+2015,Pregnancy Associated,"Ratio per 100,000 live births",68.9
+2016,Pregnancy Associated,"Ratio per 100,000 live births",82.0
+2017,Pregnancy Associated,"Ratio per 100,000 live births",69.1
+2018,Pregnancy Associated,"Ratio per 100,000 live births",74.5
+2019,Pregnancy Associated,"Ratio per 100,000 live births",76.9
+2020,Pregnancy Associated,"Ratio per 100,000 live births",102.7
+2021,Pregnancy Associated,"Ratio per 100,000 live births",92.4
 2011,Pregnancy Associated Not Related,"Ratio per 100,000 live births",41.2
 2012,Pregnancy Associated Not Related,"Ratio per 100,000 live births",41.7
 2013,Pregnancy Associated Not Related,"Ratio per 100,000 live births",40.4

--- a/data/indicator_3-1-1.csv
+++ b/data/indicator_3-1-1.csv
@@ -1,13 +1,34 @@
-Year,Race/ Ethnicity,Units,Value
-2015,,"Death per 100,000 live Births",68.9
-2015-2019,Black,"Death per 100,000 live Births",29.8
-2015-2019,White,"Death per 100,000 live Births",10.7
-2016,,"Death per 100,000 live Births",82
-2016-2020,Black,"Death per 100,000 live Births",127.3
-2016-2020,White,"Death per 100,000 live Births",72.2
-2016-2020,American Indian/ Alaska Native,"Death per 100,000 live Births",142
-2016-2020,All Other Races,"Death per 100,000 live Births",31.8
-2017,,"Death per 100,000 live Births",69.1
-2018,,"Death per 100,000 live Births",74.5
-2019,,"Death per 100,000 live Births",76.9
-2020,,"Death per 100,000 live Births",102.7
+Year,Mortality Association Type,Units,Value
+2011,Pregnancy Asociated,"Ratio per 100,000 live births",60.4
+2012,Pregnancy Asociated,"Ratio per 100,000 live births",50.6
+2013,Pregnancy Asociated,"Ratio per 100,000 live births",51.9
+2014,Pregnancy Asociated,"Ratio per 100,000 live births",70.8
+2015,Pregnancy Asociated,"Ratio per 100,000 live births",68.9
+2016,Pregnancy Asociated,"Ratio per 100,000 live births",82.0
+2017,Pregnancy Asociated,"Ratio per 100,000 live births",69.1
+2018,Pregnancy Asociated,"Ratio per 100,000 live births",74.5
+2019,Pregnancy Asociated,"Ratio per 100,000 live births",76.9
+2020,Pregnancy Asociated,"Ratio per 100,000 live births",102.7
+2021,Pregnancy Asociated,"Ratio per 100,000 live births",92.4
+2011,Pregnancy Associated Not Related,"Ratio per 100,000 live births",41.2
+2012,Pregnancy Associated Not Related,"Ratio per 100,000 live births",41.7
+2013,Pregnancy Associated Not Related,"Ratio per 100,000 live births",40.4
+2014,Pregnancy Associated Not Related,"Ratio per 100,000 live births",62.9
+2015,Pregnancy Associated Not Related,"Ratio per 100,000 live births",53.0
+2016,Pregnancy Associated Not Related,"Ratio per 100,000 live births",70.6
+2017,Pregnancy Associated Not Related,"Ratio per 100,000 live births",52.0
+2018,Pregnancy Associated Not Related,"Ratio per 100,000 live births",56.3
+2019,Pregnancy Associated Not Related,"Ratio per 100,000 live births",45.4
+2020,Pregnancy Associated Not Related,"Ratio per 100,000 live births",53.8
+2021,Pregnancy Associated Not Related,"Ratio per 100,000 live births",50.5
+2011,Pregnancy Related,"Ratio per 100,000 live births",17.5
+2012,Pregnancy Related,"Ratio per 100,000 live births",8.0
+2013,Pregnancy Related,"Ratio per 100,000 live births",10.6
+2014,Pregnancy Related,"Ratio per 100,000 live births",7.9
+2015,Pregnancy Related,"Ratio per 100,000 live births",14.1
+2016,Pregnancy Related,"Ratio per 100,000 live births",11.5
+2017,Pregnancy Related,"Ratio per 100,000 live births",9.9
+2018,Pregnancy Related,"Ratio per 100,000 live births",10.9
+2019,Pregnancy Related,"Ratio per 100,000 live births",23.2
+2020,Pregnancy Related,"Ratio per 100,000 live births",43.2
+2021,Pregnancy Related,"Ratio per 100,000 live births",37.1

--- a/indicator-config/3-1-1.yml
+++ b/indicator-config/3-1-1.yml
@@ -65,9 +65,8 @@ sources:
     periodicity: ''
     earliest_available: ''
     geographical_coverage: Detroit
-    url: >-
-      https://www.michigan.gov/mdhhs/-/media/Project/Websites/mdhhs/MCH-Epidemiology/MMMS_2015-2019-Report_final.pdf?rev=73c09aa823314d67ba532ddc2927f504&hash=D5A7B808B324EB7AA9FCE5015546B7D2
-    url_text: 2015-2019 Report
+    url: "https://www.michigan.gov/mdhhs/adult-child-serv/childrenfamilies/mmms/category-data/michigan-maternal-mortality-surveillance-mmms-program-data"
+    url_text: Michigan Maternal Mortality Surveillance (MMMS) Program - Data
     release_date: ''
     next_release: ''
     statistical_classification: ''


### PR DESCRIPTION
Updated the source of data for  the YML doc and also updated the data to help support some sort of visualization for indicator 3-1-1 . The original data set there would break the visual because it didn't differentiate Race/Ethnicity on the year. The split in data configuration where year was either a standard year or a range prevented the charts from populating. 